### PR TITLE
Fix: GRF description update caused by adding the rating 4 building

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -2,6 +2,6 @@
 
 # GRF name and description
 STR_GRF_NAME                                      	:Korean HQ
-STR_GRF_DESC                                      	:Korean HQ adds Korean style headquarters. Buildings rating 1~4 will be added soon. {}{}{BLACK}Rating 5: {SILVER}KORAIL Head office {}{}{BLACK}License: {SILVER}GNU GPL v3
+STR_GRF_DESC                                      	:Korean HQ adds Korean style headquarters. Buildings rating 1~3 will be added soon. {}{}{BLACK}Rating 4: {SILVER}KORAIL Seoul Headquaters{}{BLACK}Rating 5: {SILVER}KORAIL Head office{}{}{BLACK}License: {SILVER}GNU GPL v3
 
 STR_GRF_URL                                       	:https://github.com/SerpensNebula/Korean-HQ

--- a/lang/korean.lng
+++ b/lang/korean.lng
@@ -2,6 +2,6 @@
 
 # GRF name and description
 STR_GRF_NAME                                      	:한국 HQ
-STR_GRF_DESC                                      	:이 NewGRF는 한국 스타일의 회사 본사 건물을 추가해줍니다. 1단계와 4단계 건물은 추가 예정입니다. {}{}{BLACK}5단계: {SILVER}한국철도공사 본사 {}{}{BLACK}라이센스: {SILVER}GNU GPL v3
+STR_GRF_DESC                                      	:이 NewGRF는 한국 스타일의 회사 본사 건물을 추가해줍니다. 1단계에서 3단계 건물은 추가 예정입니다. {}{}{BLACK}4단계: {SILVER}한국철도공사 서울본부{}{BLACK}5단계: {SILVER}한국철도공사 본사{}{}{BLACK}라이센스: {SILVER}GNU GPL v3
 
 STR_GRF_URL                                       	:https://github.com/SerpensNebula/Korean-HQ


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/6beafb38-6be3-4cf7-9236-e1dd4e3b9b37)

GRF 설명 업데이트 누락 본 수정입니다.
용어 명칭은 [나무위키의 명칭](https://namu.wiki/w/%ED%95%9C%EA%B5%AD%EC%B2%A0%EB%8F%84%EA%B3%B5%EC%82%AC%20%EC%84%9C%EC%9A%B8%EB%B3%B8%EB%B6%80)을 따랐으므로 다른 의견이 있으시면 본 PR을 닫고 별도로 수정하셔도 좋습니다.